### PR TITLE
Clamp minimal texture size, for BC* textures, for avoid crashes on some hardware

### DIFF
--- a/D3D11Drv/UploadManager.cpp
+++ b/D3D11Drv/UploadManager.cpp
@@ -39,11 +39,12 @@ void UploadManager::UploadTexture(CachedTexture* tex, const FTextureInfo& Info, 
 
 	if (!tex->Texture)
 	{
+		INT MinSize = Info.Format == TEXF_BC1 || (Info.Format >= TEXF_BC2 && Info.Format <= TEXF_BC6H) ? 4 : 0;
 		D3D11_TEXTURE2D_DESC texDesc = {};
 		texDesc.Usage = D3D11_USAGE_DEFAULT;
 		texDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
-		texDesc.Width = width;
-		texDesc.Height = height;
+		texDesc.Width = Max(MinSize, width);
+		texDesc.Height = Max(MinSize, height);
 		texDesc.MipLevels = mipcount;
 		texDesc.ArraySize = 1;
 		texDesc.Format = format;


### PR DESCRIPTION
I use source format for detection, since it much easy for check. But if code expect decode BC texture, and use it later as non-BC, then need check final format, not source.